### PR TITLE
Feature/step4 database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+db/mercari.sqlite3

--- a/db/items.db
+++ b/db/items.db
@@ -1,6 +1,11 @@
-CREATE TABLE items (
-	id INTEGER PRIMARY KEY,
-	name TEXT,
-	category TEXT,
-	image_name TEXT
+CREATE TABLE IF NOT EXISTS items (
+	id	INTEGER PRIMARY KEY AUTOINCREMENT,
+	name	TEXT NOT NULL,
+	category_id	INTEGER,
+	image_name	TEXT,
+	FOREIGN KEY (category_id) REFERENCES categories(id)
+);
+CREATE TABLE IF NOT EXISTS categories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL
 );

--- a/db/items.db
+++ b/db/items.db
@@ -1,0 +1,6 @@
+CREATE TABLE items (
+　　　id INTEGER PRIMARY KEY,
+           name TEXT,
+           category TEXT,
+           image_name TEXT
+　　);

--- a/db/items.db
+++ b/db/items.db
@@ -1,6 +1,6 @@
 CREATE TABLE items (
-　　　id INTEGER PRIMARY KEY,
-           name TEXT,
-           category TEXT,
-           image_name TEXT
-　　);
+	id INTEGER PRIMARY KEY,
+	name TEXT,
+	category TEXT,
+	image_name TEXT
+);

--- a/go/app/main.go
+++ b/go/app/main.go
@@ -205,6 +205,39 @@ func getImg(c echo.Context) error {
 	return c.File(imgPath)
 }
 
+func searchItem(c echo.Context) error {
+	// get keyword value from the query
+	keyword := c.QueryParam("keyword")
+
+	// get a connection to the SQLite3 database
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	defer db.Close()
+
+	// invoke SQL to enumerate items by filtering with the `keyword` value
+	rows, err := db.Query("SELECT id, name, category, image_name FROM items WHERE name LIKE ?", "%"+keyword+"%")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	defer rows.Close()
+
+	// map the items to returned variable
+	items := Items{Items: []*Item{}}
+	for rows.Next() {
+		var item Item
+		err := rows.Scan(&item.ID, &item.Name, &item.Category, &item.ImageName)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+		items.Items = append(items.Items, &item)
+	}
+
+	// return them as JSON
+	return c.JSON(http.StatusOK, items)
+}
+
 func main() {
 	e := echo.New()
 
@@ -230,6 +263,7 @@ func main() {
 	e.GET("/items", getItems)
 	e.GET("/image/:imageFilename", getImg)
 	e.GET("/items/:itemID", getItem)
+	e.GET("/search", searchItem)
 
 	// Start server
 	e.Logger.Fatal(e.Start(":9000"))

--- a/go/app/main.go
+++ b/go/app/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -17,11 +17,12 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/labstack/gommon/log"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 const (
-	ImgDir    = "images"
-	ItemsFile = "items.json"
+	ImgDir = "images"
+	dbPath = "../db/mercari.sqlite3"
 )
 
 type Item struct {
@@ -32,7 +33,7 @@ type Item struct {
 }
 
 type Items struct {
-	Items []Item `json:"items"`
+	Items []*Item `json:"items"`
 }
 
 type Response struct {
@@ -40,53 +41,6 @@ type Response struct {
 }
 
 var itemsMap map[string]Item
-
-func mapToItemsSlice() []Item {
-	items := make([]Item, 0, len(itemsMap))
-	for _, item := range itemsMap {
-		items = append(items, item)
-	}
-	return items
-}
-
-func readItemsFromFile() (*Items, error) {
-	file, err := os.Open(ItemsFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return &Items{Items: []Item{}}, nil
-		}
-		return nil, err
-	}
-	defer file.Close()
-
-	var items Items
-	// JSON to Items
-	decoder := json.NewDecoder(file)
-	if err := decoder.Decode(&items); err != nil {
-		if err == io.EOF {
-			return &Items{Items: []Item{}}, nil
-		}
-		return nil, err
-	}
-
-	return &items, nil
-}
-
-func writeItemsToFile() error {
-	items := mapToItemsSlice()
-
-	file, err := os.Create(ItemsFile)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	encoder := json.NewEncoder(file)
-	if err := encoder.Encode(Items{Items: items}); err != nil {
-		return err
-	}
-	return nil
-}
 
 func generateHashFromImage(image *multipart.FileHeader) (string, error) {
 	src, err := image.Open()
@@ -147,45 +101,53 @@ func root(c echo.Context) error {
 func addItem(c echo.Context) error {
 	name := c.FormValue("name")
 	category := c.FormValue("category")
-
+	image, err := c.FormFile("image")
 	var imagePath string
-	contentType := c.Request().Header.Get("Content-Type")
-	// Check if the request contains a file
-	if strings.Contains(contentType, "multipart/form-data") {
-		image, err := c.FormFile("image")
-		if err == nil {
-			// image file exists
-			imageHash, err := generateHashFromImage(image)
-			if err != nil {
-				c.Logger().Errorf("Image processing error: %v", err)
-				return err
-			}
-			imagePath = filepath.Join(ImgDir, imageHash+".jpg")
-			if err := saveImage(image, imagePath); err != nil {
-				return err
-			}
-		}
-	} else {
-		// image file does not exist
+	if err != nil {
 		imagePath = "default.jpg"
+	} else {
+		imageHash, err := generateHashFromImage(image)
+		if err != nil {
+			c.Logger().Errorf("Image processing error: %v", err)
+			return err
+		}
+		imagePath = filepath.Join(ImgDir, imageHash+".jpg")
+		if err := saveImage(image, imagePath); err != nil {
+			return err
+		}
 	}
 
-	newID := strconv.Itoa(len(itemsMap) + 1)
+	// get a connection to the SQLite3 database
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	defer db.Close()
+
+	// invoke SQL to collect all of items
+	stmt, err := db.Prepare("INSERT INTO items (name, category, image_name) VALUES (?, ?, ?)")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	defer stmt.Close()
+	result, err := stmt.Exec(name, category, imagePath)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	newID, err := result.LastInsertId()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to retrieve new item ID")
+	}
 
 	newItem := Item{
-		ID:        newID,
+		ID:        strconv.Itoa(int(newID)),
 		Name:      name,
 		Category:  category,
 		ImageName: imagePath,
 	}
 
-	// Add new item to the map
-	itemsMap[newID] = newItem
-
-	// Write updated items back to file
-	if err := writeItemsToFile(); err != nil {
-		return c.JSON(http.StatusInternalServerError, Response{Message: "Failed to write item to file"})
-	}
+	itemsMap[strconv.Itoa(int(newID))] = newItem
 
 	return c.JSON(http.StatusOK, newItem)
 }
@@ -200,8 +162,33 @@ func getItem(c echo.Context) error {
 }
 
 func getItems(c echo.Context) error {
-	items := mapToItemsSlice()
-	return c.JSON(http.StatusOK, Items{Items: items})
+	// get a connection to the SQLite3 database
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	defer db.Close()
+
+	// invoke SQL to collect all of items
+	rows, err := db.Query("SELECT id, name, category, image_name FROM items")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	defer rows.Close()
+
+	// map the items to returned variable
+	items := Items{Items: []*Item{}}
+	for rows.Next() {
+		var item Item
+		err := rows.Scan(&item.ID, &item.Name, &item.Category, &item.ImageName)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+		items.Items = append(items.Items, &item)
+	}
+
+	// return them as JSON
+	return c.JSON(http.StatusOK, Items{Items: items.Items})
 }
 
 func getImg(c echo.Context) error {
@@ -234,20 +221,8 @@ func main() {
 		AllowMethods: []string{http.MethodGet, http.MethodPut, http.MethodPost, http.MethodDelete},
 	}))
 
-	// Read existing items from file at startup
-	items, err := readItemsFromFile()
-	if err != nil && !os.IsNotExist(err) {
-		e.Logger.Fatal("Failed to read items from file:", err)
-	}
-	if items == nil {
-		items = &Items{}
-	}
-
 	// Create a map of items for quick access
 	itemsMap = make(map[string]Item)
-	for _, item := range items.Items {
-		itemsMap[item.ID] = item
-	}
 
 	// Routes
 	e.GET("/", root)

--- a/go/go.mod
+++ b/go/go.mod
@@ -5,11 +5,11 @@ go 1.20
 require (
 	github.com/labstack/echo/v4 v4.7.2
 	github.com/labstack/gommon v0.3.1
+	github.com/mattn/go-sqlite3 v1.14.22
 )
 
 require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-colorable v0.1.11 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -3,8 +3,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/labstack/echo/v4 v4.7.2 h1:Kv2/p8OaQ+M6Ex4eGimg9b9e6icoxA42JSlOR3msKtI=
 github.com/labstack/echo/v4 v4.7.2/go.mod h1:xkCDAdFCIf8jsFQ5NnbK7oqaF/yU1A1X20Ltm0OvSks=
 github.com/labstack/gommon v0.3.1 h1:OomWaJXm7xR6L1HmEtGyQf26TEn7V6X88mktX9kee9o=
@@ -13,6 +11,8 @@ github.com/mattn/go-colorable v0.1.11 h1:nQ+aFkoE2TMGc0b68U2OKSexC+eq46+XwZzWXHR
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
## What
## 1. SQLiteに情報を移行する
commit: [add schema to define items table in db/items.db](https://github.com/oz1042/mercari-build-training/commit/fed9d9de76afe79416c120430b6d1e20b0a54fbf)
`mercari.sqlite3`を作成して`items.db`にitemsテーブルを作成するスキーマを追加しました。

commit: [Update GET /items and POST /items endpoints to enable retrieval of it…](https://github.com/oz1042/mercari-build-training/commit/4aed58007f0af3153858fc35d64b281d90301035)
`GET /items`と`POST /items` のエンドポイントをsqlite3を用いる処理に変更しました。

## 2. 商品を検索する
commit: [4-2 make an endpoint called GET /search](https://github.com/oz1042/mercari-build-training/commit/c13577a58d14e92f75e74a2dba9d935c10809c9d)
`GET/ search` というエンドポイントを追加し、それに対応する関数`searchItem` を実装しました。

## 3. カテゴリの情報を別のテーブルに移す
commit: [4-3 move the category information to a separate table](https://github.com/oz1042/mercari-build-training/commit/e06604d98ebb5f0ed38ec774791c33181d3315b5)
`GET/ items` エンドポイントを変更するために、関数`getItems()` を修正しました。変数名の誤りや不要なコードの削除なども一緒に修正しています。

## ToDo / 改善ポイント
- Item構造体の要素であるidは不要だから削除。
- db周りの操作を(重複をなくして)まとめる。
- Testの方法をここに追記する。

## CHECKS :warning:

Please make sure you are aware of the following.

- [x] **The changes in this PR doesn't have private information
